### PR TITLE
Remove non-existing metod

### DIFF
--- a/app/models/refinery/news/item.rb
+++ b/app/models/refinery/news/item.rb
@@ -82,7 +82,7 @@ module Refinery
 
         # rejects any item that has not been translated to the current locale.
         def translated
-          i18n.join_translations
+          i18n
         end
       end
     end


### PR DESCRIPTION
Fixes undefined method `join_translations' for #<Refinery::News::Item::ActiveRecord_Relation>